### PR TITLE
Trim whitespace after replacing placeholders

### DIFF
--- a/module.go
+++ b/module.go
@@ -1,6 +1,7 @@
 package porkbun
 
 import (
+	"strings"
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	porkbun "github.com/libdns/porkbun"
@@ -23,8 +24,8 @@ func (Provider) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the module. Implements caddy.Provisioner.
 func (p *Provider) Provision(ctx caddy.Context) error {
-	p.Provider.APIKey = caddy.NewReplacer().ReplaceAll(p.Provider.APIKey, "")
-	p.Provider.APISecretKey = caddy.NewReplacer().ReplaceAll(p.Provider.APISecretKey, "")
+	p.Provider.APIKey = strings.TrimSpace(caddy.NewReplacer().ReplaceAll(p.Provider.APIKey, ""))
+	p.Provider.APISecretKey = strings.TrimSpace(caddy.NewReplacer().ReplaceAll(p.Provider.APISecretKey, ""))
 	return nil
 }
 


### PR DESCRIPTION
This tripped me up when reading the keys from a file using a placeholder (see https://github.com/caddyserver/caddy/pull/5463) due to the ending newline which the majority of text editors added.

Realistically, I don't see much of a negative to trimming or atleast trimming newlines (this pull request does all whitespace).
